### PR TITLE
MOD: local math_path to avoid warning

### DIFF
--- a/jsonpath.lua
+++ b/jsonpath.lua
@@ -427,7 +427,7 @@ end
 
 
 
-function match_path(ast, path, parent, obj)
+local function match_path(ast, path, parent, obj)
     local descendants = false
     local ast_iter = ipairs(ast)
     local ast_key, ast_spec = ast_iter(ast, 0)


### PR DESCRIPTION
Minor fix to avoid warnings
```
[lua] _G write guard:12: __newindex(): writing a global Lua variable ('match_path') which may lead to race conditions between concurrent requests, so prefer the use of 'local' variables
stack traceback:
```